### PR TITLE
feat(confirm dialog): added custom store prop to allow for isolated o…

### DIFF
--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -13,5 +13,10 @@
 export { default as DescriptionList } from './src/DescriptionList/DescriptionList';
 export { default as DocumentViewer } from './src/DocumentViewer/DocumentViewer';
 export { default as Modal } from './src/Modal/Modal';
-export { default as ConfirmDialog, confirm } from './src/ConfirmDialog/ConfirmDialog';
+export {
+	default as ConfirmDialog,
+	confirm,
+	IState as IConfirmDialogStoreState,
+	initialState as initialConfirmDialogState,
+} from './src/ConfirmDialog/ConfirmDialog';
 export { default as DocumentTable } from './src/DocumentTable/DocumentTable';

--- a/src/common/src/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/src/common/src/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import ConfirmDialog, { confirm } from './ConfirmDialog';
+import { BehaviorSubject } from 'rxjs';
+import ConfirmDialog, { confirm, initialState, IState } from './ConfirmDialog';
 
 const props = {
 	title: 'Waarschuwing',
@@ -15,6 +16,8 @@ const props = {
 		console.log('sluiten');
 	},
 };
+
+const customSubject = new BehaviorSubject<IState>(initialState);
 
 storiesOf('Confirm Dialog', module)
 	.add('Default', () => (
@@ -39,5 +42,22 @@ storiesOf('Confirm Dialog', module)
 		<>
 			<button onClick={() => confirm(props)}>Verwijder</button>
 			<ConfirmDialog backdropOpacity={1} />
+		</>
+	))
+	.add('With custom subject', () => (
+		<>
+			<button onClick={() => confirm(props)}>Verwijder</button>
+			<ConfirmDialog />
+			<button
+				onClick={() =>
+					confirm(
+						{ ...props, message: 'This message comes from a BehaviorSubject with an isolated state' },
+						customSubject,
+					)
+				}
+			>
+				Verwijder
+			</button>
+			<ConfirmDialog store={customSubject} />
 		</>
 	));

--- a/src/common/src/ConfirmDialog/ConfirmDialog.test.tsx
+++ b/src/common/src/ConfirmDialog/ConfirmDialog.test.tsx
@@ -2,9 +2,11 @@ import type { IState, Props } from './ConfirmDialog';
 
 import React, { ComponentProps } from 'react';
 import { screen } from '@testing-library/dom';
-import { mockComponentProps } from '~/tests/helpers';
-import { Modal } from '@amsterdam/asc-ui';
+import { Modal, ThemeProvider } from '@amsterdam/asc-ui';
 import { act, fireEvent, render, waitFor } from '@testing-library/react';
+import { mockComponentProps } from '~/tests/helpers';
+
+import theme from '../../../theme/theme';
 
 describe('<ConfirmDialog />', () => {
 	const onClick = jest.fn();
@@ -19,14 +21,18 @@ describe('<ConfirmDialog />', () => {
 		onConfirm: onClick,
 	};
 
-	const clickAndRenderDialog = async (args: Partial<IState> = defaultArg, props: Partial<Props> = {}) => {
+	const clickAndRenderDialog = async (
+		args: Partial<IState> = defaultArg,
+		props: Partial<Props> = {},
+		customSubject: Props['store'] = undefined,
+	) => {
 		const { default: ConfirmDialog, confirm } = await import('../ConfirmDialog/ConfirmDialog');
 		act(() => {
 			render(
-				<>
-					<button data-testid="open-dialog" onClick={() => confirm(args as IState)} />
-					<ConfirmDialog {...props} />
-				</>,
+				<ThemeProvider overrides={theme}>
+					<button data-testid="open-dialog" onClick={() => confirm(args as IState, customSubject)} />
+					<ConfirmDialog {...props} store={customSubject} />
+				</ThemeProvider>,
 			);
 		});
 		const button = screen.getByTestId('open-dialog');
@@ -127,4 +133,19 @@ describe('<ConfirmDialog />', () => {
 			});
 		});
 	});
+
+	test.todo('Custom BehaviorSubject for isolated state');
+	/* This test works but produces untraceable output :/
+	   Storybook has a working example though
+	test('Custom BehaviorSubject for isolated state', async () => {
+		const customSubject = new BehaviorSubject<IState>(initialState);
+		jest.isolateModules(async () => {
+			await clickAndRenderDialog(undefined, undefined, customSubject);
+			await waitFor(() => {
+				expect(screen.queryByTestId('modal')).toBeInTheDocument();
+				expect(screen.queryByTestId('modal-close-button')).not.toBeInTheDocument();
+			});
+		});
+	});
+	*/
 });

--- a/src/common/src/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/common/src/ConfirmDialog/ConfirmDialog.tsx
@@ -23,23 +23,27 @@ export type Props = {
 	zIndexOffset?: number;
 	disablePortal?: boolean;
 	open?: boolean;
+	store?: BehaviorSubject<IState>;
 };
 
-const initialState: IState = {
+export const initialState: IState = {
 	message: '',
 	onConfirm: () => {},
 };
 
-const store = new BehaviorSubject(initialState);
+const subject = new BehaviorSubject<IState>(initialState);
 
-export const confirm = ({
-	title = 'Waarschuwing',
-	message = 'Weet u zeker dat u dit item definitief wilt verwijderen?',
-	textConfirmButton = 'Ja',
-	textCancelButton = 'Nee',
-	onConfirm = () => {},
-	onCancel,
-}: IState) => {
+export const confirm = (
+	{
+		title = 'Waarschuwing',
+		message = 'Weet u zeker dat u dit item definitief wilt verwijderen?',
+		textConfirmButton = 'Ja',
+		textCancelButton = 'Nee',
+		onConfirm = () => {},
+		onCancel,
+	}: IState,
+	store = subject,
+) => {
 	store.next({ title, message, textConfirmButton, textCancelButton, onCancel, onConfirm });
 };
 
@@ -52,6 +56,7 @@ const ConfirmDialog: IConfirmDialog = ({
 	zIndexOffset = 1,
 	disablePortal = false,
 	open = false,
+	store = subject,
 }: Props) => {
 	const [state, setState] = React.useState<IState>(initialState);
 	const [isVisible, setIsVisible] = React.useState<boolean>(open);

--- a/src/common/src/ConfirmDialog/README.md
+++ b/src/common/src/ConfirmDialog/README.md
@@ -1,0 +1,41 @@
+The `<ConfirmDialog />` component was developed with the idea that a single `<ConfirmDialog />` exists in your 
+application component tree. A  RXJS `BehaviorSubject` instance that manages the state of the dialog is shared 
+between all features that want to raise a confirmation dialog based on this component.
+
+To raise a confirmation prompt (after adding `<ConfirmDialog />` in the component tree):
+```typescript jsx
+import { confirm } from '@amsterdam/bmi-component-library';
+
+confirm({
+	title: 'Annuleer uploaden',
+	message: 'U annuleert het uploaden. Eventueel zojuist toegevoegde bestanden zullen worden verwijderd',
+	textCancelButton: 'Terug',
+	textConfirmButton: 'Akkoord',
+	// ...
+});
+
+<ConfirmDialog />
+```
+
+## Usage of <ConfirmDialog /> in an NPM package/micro-frontend
+
+If you want to use a `<ConfirmDialog />` in an NPM package which effectively contains a micro-frontend, it is 
+important to isolate the state of the `BehaviorSubject` instance to avoid multiple `<ConfirmDialog />` components to 
+become visible simultaneously. You can do this by passing your own instance:
+
+```typescript jsx
+import { BehaviorSubject } from 'rxjs';
+import { confirm, ConfirmDialog } from '@amsterdam/bmi-component-library';
+
+const customSubject = new BehaviorSubject();
+
+confirm({
+	title: 'Annuleer uploaden',
+	message: 'U annuleert het uploaden. Eventueel zojuist toegevoegde bestanden zullen worden verwijderd',
+	textCancelButton: 'Terug',
+	textConfirmButton: 'Akkoord',
+	// ...
+}, customSubject);
+
+<ConfirmDialog store={customSubject} />
+```


### PR DESCRIPTION
…peration of a confirm dialog

This was necessary due to the way the `<ConfirmDialog />` was implemented in @amsterdam/bmi-dms-upload. Without this we'd need to do some serious refactoring and move wizard termination logic to the implementation side (i.e.: DMS/AIP).