### PR TITLE
feat(confirm dialog): confirm dialog can now be passed a react node a…

### DIFF
--- a/src/common/src/ConfirmDialog/ConfirmDialog.stories.tsx
+++ b/src/common/src/ConfirmDialog/ConfirmDialog.stories.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { BehaviorSubject } from 'rxjs';
+import styled from 'styled-components';
+
 import ConfirmDialog, { confirm, initialState, IState } from './ConfirmDialog';
 
-const props = {
+const props: IState = {
 	title: 'Waarschuwing',
 	message: 'Weet u zeker dat u dit document definitief wilt verwijderen?',
 	onCancel: () => {
@@ -18,6 +20,28 @@ const props = {
 };
 
 const customSubject = new BehaviorSubject<IState>(initialState);
+
+const ReactNodeExample = styled.div`
+	font-size: 18px;
+	line-height: 28px;
+
+	p {
+		margin-top: 0;
+	}
+
+	dl {
+		background-color: rgba(0, 70, 153, 0.2);
+		padding: 8px 32px 8px 8px;
+
+		dt,
+		dd {
+			display: table-cell;
+			vertical-align: middle;
+			padding: 0 24px 0 0;
+			color: #000000;
+		}
+	}
+`;
 
 storiesOf('Confirm Dialog', module)
 	.add('Default', () => (
@@ -46,8 +70,6 @@ storiesOf('Confirm Dialog', module)
 	))
 	.add('With custom subject', () => (
 		<>
-			<button onClick={() => confirm(props)}>Verwijder</button>
-			<ConfirmDialog />
 			<button
 				onClick={() =>
 					confirm(
@@ -60,4 +82,32 @@ storiesOf('Confirm Dialog', module)
 			</button>
 			<ConfirmDialog store={customSubject} />
 		</>
-	));
+	))
+	.add('With React node as message', () => {
+		return (
+			<>
+				<button
+					onClick={() =>
+						confirm({
+							...props,
+							title: 'Element verwijderen',
+							message: (
+								<ReactNodeExample>
+									<p>Weet u zeker dat u dit element wilt verwijderen?</p>
+									<dl>
+										<dt>111</dt>
+										<dd>Bebording/bewegwijzering (statisch)</dd>
+									</dl>
+								</ReactNodeExample>
+							),
+							textConfirmButton: 'Verwijder',
+							textCancelButton: 'Annuleer',
+						})
+					}
+				>
+					Verwijder
+				</button>
+				<ConfirmDialog hideCloseButton={false} />
+			</>
+		);
+	});

--- a/src/common/src/ConfirmDialog/ConfirmDialog.test.tsx
+++ b/src/common/src/ConfirmDialog/ConfirmDialog.test.tsx
@@ -148,4 +148,24 @@ describe('<ConfirmDialog />', () => {
 		});
 	});
 	*/
+
+	test('Renders a ReactNode for a confirmation message', () => {
+		jest.isolateModules(async () => {
+			await clickAndRenderDialog(
+				{
+					title: 'Element verwijderen',
+					message: <p data-testid="react-node-message">Weet u zeker dat u dit element wilt verwijderen?</p>,
+					textCancelButton: 'Annuleer',
+					textConfirmButton: 'Verwijder',
+					...callbackMocks,
+				},
+				{},
+			);
+
+			await waitFor(() => {
+				expect(screen.queryByTestId('modal')).toBeInTheDocument();
+				expect(screen.getByText('Weet u zeker dat u dit element wilt verwijderen?')).toBeInTheDocument();
+			});
+		});
+	});
 });

--- a/src/common/src/ConfirmDialog/ConfirmDialog.tsx
+++ b/src/common/src/ConfirmDialog/ConfirmDialog.tsx
@@ -1,12 +1,11 @@
 import { Heading } from '@amsterdam/asc-ui';
-import React, { useEffect } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 import { BehaviorSubject } from 'rxjs';
 import Modal from '../Modal/Modal';
-import { ModalBlockStyle } from '../Modal/ModalStyles';
-import { ButtonStyles } from './ConfirmDialogStyles';
+import { ButtonStyles, MessageStyle } from './ConfirmDialogStyles';
 
 export interface IState {
-	message: string;
+	message: ReactNode;
 	onConfirm: () => void;
 	title?: string;
 	textCancelButton?: string;
@@ -64,7 +63,7 @@ const ConfirmDialog: IConfirmDialog = ({
 	useEffect(() => {
 		store.subscribe((props) => {
 			setState({ ...props });
-			if (props.message.length > 0) {
+			if (props.message) {
 				setIsVisible(true);
 			}
 		});
@@ -91,10 +90,10 @@ const ConfirmDialog: IConfirmDialog = ({
 				}}
 				hideCloseButton={hideCloseButton}
 			>
-				<Heading forwardedAs="h4">{state.title}</Heading>
+				<Heading forwardedAs="h1">{state.title}</Heading>
 			</Modal.TopBar>
 			<Modal.Content>
-				<ModalBlockStyle>{state.message}</ModalBlockStyle>
+				<MessageStyle message={state.message}>{state.message}</MessageStyle>
 			</Modal.Content>
 			<Modal.Actions>
 				<Modal.Actions.Left>

--- a/src/common/src/ConfirmDialog/ConfirmDialogStyles.tsx
+++ b/src/common/src/ConfirmDialog/ConfirmDialogStyles.tsx
@@ -1,5 +1,13 @@
 import styled from 'styled-components';
-import { Button } from '@amsterdam/asc-ui';
+import { Button, themeSpacing } from '@amsterdam/asc-ui';
+import { ModalBlockStyle } from '../Modal/ModalStyles';
+
+import type { ReactNode } from 'react';
+
+export const MessageStyle = styled(ModalBlockStyle)<{ message: ReactNode }>`
+	/* Reduce default margin-top on modal content in case message consists of HTML elements (ReactNode) */
+	margin-top: ${({ message }) => (typeof message === 'string' ? themeSpacing(3) : themeSpacing(2))};
+`;
 
 export const ButtonStyles = styled(Button)`
 	justify-content: center;

--- a/src/common/src/Modal/ModalContent/ModalContentStyles.ts
+++ b/src/common/src/Modal/ModalContent/ModalContentStyles.ts
@@ -5,10 +5,6 @@ const ModalContentStyle = styled.div`
 	overflow-x: hidden;
 	max-height: calc(90vh - 128px);
 
-	> *:first-child {
-		margin-top: 0;
-	}
-
 	> *:last-child {
 		margin-bottom: 0;
 	}

--- a/src/common/src/Modal/ModalTopBar/ModalTopBarStyles.ts
+++ b/src/common/src/Modal/ModalTopBar/ModalTopBarStyles.ts
@@ -4,7 +4,7 @@ import { TopBar, Divider, breakpoint, themeSpacing } from '@amsterdam/asc-ui';
 export const ModalTopBarStyle = styled(TopBar)<{ hideDivider: boolean }>`
 	display: grid;
 	grid-template-columns: 1fr auto;
-	grid-template-rows: 44px ${themeSpacing(6)};
+	grid-template-rows: 44px ${({ hideDivider }) => (hideDivider ? 0 : themeSpacing(6))};
 	padding: 0;
 	margin-bottom: ${({ hideDivider }) => (hideDivider ? 0 : '12px')};
 


### PR DESCRIPTION
…s the message

From storybook:
![image](https://user-images.githubusercontent.com/1095870/205840144-689a9ac7-5511-4b41-8a47-079a7b399a90.png)
